### PR TITLE
Add isatty() to ColoredStream

### DIFF
--- a/awslambda/deploy.py
+++ b/awslambda/deploy.py
@@ -34,7 +34,10 @@ class ColoredStream(object):
 
     def flush(self):
         self.__s.flush()
-
+        
+    def isatty(self):
+        return self.__s.isatty()
+    
 
 @contextmanager
 def do_thing(name):


### PR DESCRIPTION
Some versions of pip expect sys.stdout to implement isatty().

This change prevents: "AttributeError: 'ColoredStream' object has no attribute 'isatty'"
